### PR TITLE
feat(trick): implement image upload with VichUploaderBundle and dynamic display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "symfony/property-info": "7.2.*",
         "symfony/runtime": "7.2.*",
         "symfony/security-bundle": "7.2.*",
+        "symfony/security-core": "7.2.*",
         "symfony/serializer": "7.2.*",
         "symfony/stimulus-bundle": "^2.23",
         "symfony/string": "7.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "865edaaa110490e9450ab09350eb998d",
+    "content-hash": "9954b9b83392377a68112e17d3b4de69",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -6301,16 +6301,16 @@
         },
         {
             "name": "symfony/security-core",
-            "version": "v7.2.3",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "466784ffcd0b5a16e05394335897f790b17d07e4"
+                "reference": "340e120d26b3bf5eee5cea0782aebaa2f36b6722"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/466784ffcd0b5a16e05394335897f790b17d07e4",
-                "reference": "466784ffcd0b5a16e05394335897f790b17d07e4",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/340e120d26b3bf5eee5cea0782aebaa2f36b6722",
+                "reference": "340e120d26b3bf5eee5cea0782aebaa2f36b6722",
                 "shasum": ""
             },
             "require": {
@@ -6368,7 +6368,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v7.2.3"
+                "source": "https://github.com/symfony/security-core/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -6384,7 +6384,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-27T11:08:17+00:00"
+            "time": "2025-04-17T08:47:02+00:00"
         },
         {
             "name": "symfony/security-csrf",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,24 +1,15 @@
-# This file is the entry point to configure your own services.
-# Files in the packages/ subdirectory configure your dependencies.
-
-# Put parameters here that don't need to change on each machine where the app is deployed
-# https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
-parameters:
+parameters: {}
 
 services:
-    # default configuration for services in *this* file
-    _defaults:
-        autowire: true      # Automatically injects dependencies in your services.
-        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
 
-    # makes classes in src/ available to be used as services
-    # this creates a service per class whose id is the fully-qualified class name
+
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
     App\:
         resource: '../src/'
         exclude:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-
-    # add more service definitions when explicit configuration is needed
-    # please note that last definitions always *replace* previous ones

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -2,8 +2,11 @@
 
 namespace App\Entity;
 
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Symfony\Component\HttpFoundation\File\File;
 use Doctrine\ORM\Mapping as ORM;
 
+#[Vich\Uploadable]
 #[ORM\Entity]
 class Image implements MediaInterface
 {
@@ -17,6 +20,12 @@ class Image implements MediaInterface
 
     #[ORM\Column(nullable: false)]
     private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    #[Vich\UploadableField(mapping: 'trick_images', fileNameProperty: 'url')]
+    private ?File $imageFile = null;
 
     #[ORM\ManyToOne(inversedBy: 'images')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -34,9 +43,6 @@ class Image implements MediaInterface
 
     public function getUrl(): ?string
     {
-        if (!$this->url) {
-            dd ($this);
-        }
         return $this->url;
     }
 
@@ -57,6 +63,17 @@ class Image implements MediaInterface
         return $this;
     }
 
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): static
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
     public function getTrick(): ?Trick
     {
         return $this->trick;
@@ -66,5 +83,19 @@ class Image implements MediaInterface
     {
         $this->trick = $trick;
         return $this;
+    }
+
+    public function setImageFile(?File $file = null): void
+    {
+        $this->imageFile = $file;
+
+        if ($file !== null) {
+            $this->updatedAt = new \DateTimeImmutable();
+        }
+    }
+
+    public function getImageFile(): ?File
+    {
+        return $this->imageFile;
     }
 }

--- a/src/Entity/Trick.php
+++ b/src/Entity/Trick.php
@@ -36,7 +36,7 @@ class Trick
     #[ORM\Column(nullable: false)]
     private ?\DateTimeImmutable $createdAt = null;
 
-    #[ORM\Column(nullable: false)]
+    #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $updatedAt = null;
 
     #[ORM\ManyToOne(inversedBy: 'tricks')]

--- a/src/Form/NewTricksForm.php
+++ b/src/Form/NewTricksForm.php
@@ -6,12 +6,14 @@ use App\Enum\Difficulty;
 use App\Enum\TrickType;
 use App\Entity\Trick;
 use App\Entity\User;
+use App\Form\TrickImageType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
 class NewTricksForm extends AbstractType
 {
@@ -36,6 +38,13 @@ class NewTricksForm extends AbstractType
                 'placeholder' => 'Choose a difficulty',
                 'row_attr' => ['class' => 'new-trick-form-difficulty'],
             ])
+            ->add('images', CollectionType::class, [
+                'entry_type' => TrickImageType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'label' => false,
+            ]);
         ;
     }
 

--- a/src/Form/TrickImageType.php
+++ b/src/Form/TrickImageType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use App\Entity\Image;
+
+class TrickImageType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('imageFile', FileType::class, [
+                'label' => 'Image',
+                'required' => true,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Image::class,
+        ]);
+    }
+}

--- a/src/Naming/UserBasedNamer.php
+++ b/src/Naming/UserBasedNamer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Naming;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Naming\NamerInterface;
+
+class UserBasedNamer implements NamerInterface
+{
+    public function __construct(private Security $security) {}
+
+    public function name($object, PropertyMapping $mapping): string
+    {
+        /** @var UploadedFile $file */
+        $file = $mapping->getFile($object);
+        $ext = $file->guessExtension() ?: 'bin';
+        $user = $this->security->getUser();
+        $userId = $user ? $user->getId() : 'anon';
+        $rand = random_int(1000, 9999);
+
+        return sprintf('%s_%s.%s', $userId, $rand, $ext);
+    }
+}

--- a/templates/partials/navbar.html.twig
+++ b/templates/partials/navbar.html.twig
@@ -17,7 +17,7 @@
         <i class="fas fa-home"></i>
     </a>
 
-    <a href="{{ path('trick') }}">
+    <a href="{{ path('trick_new') }}">
         <i class="fas fa-snowboarding"></i>
     </a>
 

--- a/templates/trick/create.html.twig
+++ b/templates/trick/create.html.twig
@@ -1,6 +1,4 @@
 {% extends "layouts/base.html.twig" %}
-
-{% block title %}Nouveau trick{% endblock %}
 {% block head %}
     {{ parent() }}
     <style>
@@ -8,23 +6,38 @@
     </style>
 {% endblock %}
 
-{% block content %}
-<div class="form-page">
+{% block title %}Nouveau trick{% endblock %}
 
-    {% if is_granted('IS_AUTHENTICATED_FULLY') %}
-    <h1 class="form-title">Créer un nouveau trick</h1>
-    <form method="post" class="form-form">
-        {{ form_start(form) }}
-        {{ form_widget(form) }}
-        <button type="submit">Créer</button>
-        {{ form_end(form) }}
-    </form>
-    {% else %}
-        <h2>Vous devez être connecté pour créer un trick</h2>
-        <p>
-            <a href="{{ path('app_login') }}">Se connecter</a> ou
-            <a href="{{ path('app_register') }}">Créer un compte</a>
-        </p>
-    {% endif %}
-</div>
+{% block content %}
+    <div class="form-page">
+
+        {% if is_granted('IS_AUTHENTICATED_FULLY') %}
+
+            <h1 class="form-title">Créer un nouveau trick</h1>
+                <div class="form-form">
+
+            {{ form_start(form, { 'attr': { 'enctype': 'multipart/form-data' } }) }}
+
+            {{ form_row(form.name) }}
+            {{ form_row(form.description) }}
+            {{ form_row(form.Trick_Type) }}
+            {{ form_row(form.difficulty) }}
+
+            <h3>Images</h3>
+            {% for imageForm in form.images %}
+                {{ form_row(imageForm.imageFile) }}
+            {% endfor %}
+
+            <button type="submit">Créer</button>
+
+            {{ form_end(form) }}
+
+        {% else %}
+            <h2>Vous devez être connecté pour créer un trick</h2>
+            <p>
+                <a href="{{ path('app_login') }}">Se connecter</a> ou
+                <a href="{{ path('app_register') }}">Créer un compte</a>
+            </p>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/templates/trick/index.html.twig
+++ b/templates/trick/index.html.twig
@@ -16,7 +16,7 @@
                     {% set displayed = false %}
                     {% for image in trick.images %}
                         {% if not displayed %}
-                            <img src="{{ asset(image.url) }}" alt="Image de {{ trick.name }}" class="card-image">
+                            <img src="{{ asset('uploads/tricks/images/' ~ image.url) }}" alt="Image de {{ trick.name }}" class="card-image">
                             {% set displayed = true %}
                         {% endif %}
                     {% endfor %}

--- a/templates/trick/show.html.twig
+++ b/templates/trick/show.html.twig
@@ -16,7 +16,7 @@
         {% set bannerImage = null %}
         {% for image in trick.images %}
             {% if loop.first %}
-                {% set bannerImage = asset(image.url) %}
+                {% set bannerImage = asset('uploads/tricks/images/' ~ image.url) %}
             {% endif %}
         {% endfor %}
 
@@ -37,7 +37,7 @@
             {% if hasImages %}
                 {% for image in trick.images %}
                     <div class="media-item">
-                        <img src="{{ asset(image.url) }}" alt="Image du trick">
+                        <img src="{{ asset('uploads/tricks/images/' ~ image.url) }}" alt="Image du trick">
                     </div>
                 {% endfor %}
             {% else %}
@@ -64,8 +64,12 @@
         <section class="articles">
             <article>
                 <div class="metadata">
-                    Écrit le {{ trick.createdAt|date('d/m/Y') }} à {{ trick.createdAt|date('H:i') }},
-                    modifié le {{ trick.updatedAt|date('d/m/Y') }} à {{ trick.updatedAt|date('H:i') }}
+                    Écrit le {{ trick.createdAt ? trick.createdAt|date('d/m/Y') ~ ' à ' ~ trick.createdAt|date('H:i') : 'date inconnue' }},
+                    {% if trick.updatedAt %}
+                        modifié le {{ trick.updatedAt|date('d/m/Y') }} à {{ trick.updatedAt|date('H:i') }}
+                    {% else %}
+                        jamais modifié
+                    {% endif %}
                 </div>
                 <div class="content">
                     {{ trick.description|raw }}


### PR DESCRIPTION
- Integrated VichUploaderBundle for handling image uploads related to tricks
- Added `imageFile` field in the `Image` entity with `trick_images` mapping
- Stored uploaded file name in `url` and saved files to `/public/uploads/tricks/images`
- Displayed uploaded images in trick detail view (banner and gallery)
- Used `OrignameNamer` to keep original file names
- Fixed Doctrine column type for `updatedAt` (datetime)
- Ensured proper date rendering in Twig with null-safe conditions
- Improved form and controller logic to correctly associate images with tricks